### PR TITLE
feat(cli): scaffold Go project skeleton (PR#1 of #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Binaries
-mask-pipe
-mask-pipe.exe
-bin/
-dist/
+/mask-pipe
+/mask-pipe.exe
+/bin/
+/dist/
 
 # Go
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+GO      ?= go
+BIN     := mask-pipe
+VERSION ?= dev
+COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT)
+
+.PHONY: all build test clean
+
+all: build
+
+build:
+	$(GO) build -ldflags "$(LDFLAGS)" -o $(BIN) ./cmd/mask-pipe
+
+test:
+	$(GO) test ./...
+
+clean:
+	rm -f $(BIN)

--- a/cmd/mask-pipe/main.go
+++ b/cmd/mask-pipe/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+)
+
+const usage = `mask-pipe — filter secrets from terminal output
+
+Usage:
+  <command> | mask-pipe [flags]
+
+Flags:
+  -h, --help      show this help and exit
+  -V, --version   show version and exit
+
+Example:
+  aws sts get-caller-identity 2>&1 | mask-pipe
+`
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("mask-pipe", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	var (
+		showHelp    bool
+		showVersion bool
+	)
+	fs.BoolVar(&showHelp, "help", false, "")
+	fs.BoolVar(&showHelp, "h", false, "")
+	fs.BoolVar(&showVersion, "version", false, "")
+	fs.BoolVar(&showVersion, "V", false, "")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "mask-pipe: %v\n", err)
+		fmt.Fprint(stderr, usage)
+		return 2
+	}
+
+	switch {
+	case showHelp:
+		fmt.Fprint(stdout, usage)
+		return 0
+	case showVersion:
+		fmt.Fprintf(stdout, "mask-pipe %s (%s)\n", version, commit)
+		return 0
+	}
+
+	if _, err := io.Copy(stdout, stdin); err != nil && !errors.Is(err, io.EOF) {
+		fmt.Fprintf(stderr, "mask-pipe: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/mask-pipe/main_test.go
+++ b/cmd/mask-pipe/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVersionFlag(t *testing.T) {
+	for _, arg := range []string{"--version", "-V"} {
+		t.Run(arg, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run([]string{arg}, strings.NewReader(""), &stdout, &stderr)
+			if code != 0 {
+				t.Errorf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "mask-pipe") {
+				t.Errorf("stdout = %q, want to contain \"mask-pipe\"", stdout.String())
+			}
+		})
+	}
+}
+
+func TestHelpFlag(t *testing.T) {
+	for _, arg := range []string{"--help", "-h"} {
+		t.Run(arg, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run([]string{arg}, strings.NewReader(""), &stdout, &stderr)
+			if code != 0 {
+				t.Errorf("exit code = %d, want 0", code)
+			}
+			if !strings.Contains(stdout.String(), "Usage") {
+				t.Errorf("stdout missing Usage section: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestInvalidFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--bogus"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+	if stderr.Len() == 0 {
+		t.Error("stderr should contain an error message")
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout should be empty on flag error, got %q", stdout.String())
+	}
+}
+
+func TestPassthrough(t *testing.T) {
+	input := "hello\nworld\n"
+	var stdout, stderr bytes.Buffer
+	code := run(nil, strings.NewReader(input), &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if stdout.String() != input {
+		t.Errorf("stdout = %q, want %q", stdout.String(), input)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/c12o-dev/mask-pipe
+
+go 1.23


### PR DESCRIPTION
First of three PRs for the MVP vertical slice (#1). Lays down the minimum Go project structure so subsequent PRs can plug pattern detection and filter-engine wiring into a working shell.

## What's in

- `go.mod` — module `github.com/c12o-dev/mask-pipe`, Go 1.23
- `cmd/mask-pipe/main.go` — `flag.NewFlagSet` based parsing, `--help`/`-h`, `--version`/`-V`, stdin→stdout passthrough stub via `io.Copy`
- `cmd/mask-pipe/main_test.go` — exit-code and I/O assertions for each flag surface and the passthrough path (4 tests, all passing)
- `Makefile` — `build` / `test` / `clean` targets; `LDFLAGS` inject `main.version` and `main.commit` at build time
- `.gitignore` — anchored the binary entries (`/mask-pipe`, `/bin/`, `/dist/`) so they stop shadowing the `cmd/mask-pipe/` directory

## What's out (deferred to PR#2 / PR#3 of #1)

- Pattern struct and `aws_access_key` regex → PR#2
- Line-by-line filter engine that replaces `io.Copy` and actually masks → PR#3

## Layout

Follows ADR 0003 (#9): `cmd/mask-pipe/` entry point, top-level `patterns/` (to appear in PR#2), `internal/*` for private packages. No `pkg/`.

## Verification

```console
$ go build -o mask-pipe ./cmd/mask-pipe
$ ./mask-pipe --version
mask-pipe dev (none)
$ echo 'AKIAIOSFODNN7EXAMPLE' | ./mask-pipe
AKIAIOSFODNN7EXAMPLE     # expected — masking lands in PR#3
$ ./mask-pipe --bogus ; echo \$?
mask-pipe: flag provided but not defined: -bogus
...
2
$ go test ./...
ok  github.com/c12o-dev/mask-pipe/cmd/mask-pipe
$ go vet ./... && gofmt -l .   # both clean
```

`make build` / `make test` not verified in the dev environment (no `make` installed) but the Makefile follows standard syntax; CI or a reviewer with `make` can confirm.

## Test plan

- [ ] `go build ./cmd/mask-pipe` produces a working binary on reviewer's machine
- [ ] `go test ./...` passes
- [ ] `make build` produces the same binary (if `make` available)
- [ ] `--help` exits 0 with usage on stdout
- [ ] `--version` exits 0 with `mask-pipe <version> (<sha>)` on stdout
- [ ] Unknown flag exits 2 with error on stderr
- [ ] `echo hello | ./mask-pipe` prints `hello` unchanged (masking not yet wired)

## Order of merge

Independent of the ADR PR (#9), but #9 should land first so the layout rationale is in `main` when reviewers browse `cmd/mask-pipe/`.

Refs #1