### PR TITLE
feat(patterns): add Pattern struct + aws_access_key (PR#2 of #1)

### DIFF
--- a/patterns/aws_access_key.go
+++ b/patterns/aws_access_key.go
@@ -1,0 +1,27 @@
+package patterns
+
+import "regexp"
+
+var awsAccessKey = &Pattern{
+	ID:         "aws_access_key",
+	Name:       "AWS Access Key ID",
+	Regex:      regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+	CaptureIdx: 0,
+	Examples: []string{
+		"AKIAIOSFODNN7EXAMPLE",
+		"AKIAI44QH8DHBEXAMPLE",
+		"AKIAJQABCDEFGHIJKLMN",
+		"AKIAZZZZ9999AAAABBBB",
+		"AKIA2RAY6KGQJM7Q3EYX",
+	},
+	NonExamples: []string{
+		"AKIA",
+		"AKIAIOSFODNN7EXAM",
+		"XKIAIOSFODNN7EXAMPLE",
+		"akiaiosfodnn7example",
+		"AKIAIOSFODNN!EXAMPLE",
+		"AKIAiosfodnn7example",
+		"BKIAIOSFODNN7EXAMPLE",
+	},
+	Source: "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html",
+}

--- a/patterns/builtins.go
+++ b/patterns/builtins.go
@@ -1,0 +1,6 @@
+package patterns
+
+// Builtins is the default set of built-in patterns, in match-priority order.
+var Builtins = []*Pattern{
+	awsAccessKey,
+}

--- a/patterns/doc.go
+++ b/patterns/doc.go
@@ -1,0 +1,5 @@
+// Package patterns defines the built-in secret detection patterns shipped with mask-pipe.
+//
+// This package is top-level (per ADR 0003) for findability. It is NOT a stable
+// external API in v1; importers outside this module get no semver guarantees.
+package patterns

--- a/patterns/pattern.go
+++ b/patterns/pattern.go
@@ -1,0 +1,36 @@
+package patterns
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Pattern describes a single secret-detection rule.
+//
+// Replacement: empty string applies DefaultMask (show head + stars + tail);
+// non-empty string is used as a literal replacement (e.g. "****").
+type Pattern struct {
+	ID          string
+	Name        string
+	Regex       *regexp.Regexp
+	CaptureIdx  int
+	Replacement string
+	Examples    []string
+	NonExamples []string
+	Source      string
+}
+
+const DefaultShowTail = 4
+
+// DefaultMask keeps the first 4 and last showTail characters visible.
+// showTail <= 0 fully masks the value.
+func DefaultMask(value string, showTail int) string {
+	if showTail <= 0 {
+		return strings.Repeat("*", len(value))
+	}
+	const head = 4
+	if len(value) <= head+showTail {
+		return strings.Repeat("*", len(value))
+	}
+	return value[:head] + strings.Repeat("*", len(value)-head-showTail) + value[len(value)-showTail:]
+}

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1,0 +1,110 @@
+package patterns
+
+import (
+	"testing"
+)
+
+func TestBuiltinsHaveMinimumExamples(t *testing.T) {
+	for _, p := range Builtins {
+		if len(p.Examples) < 5 {
+			t.Errorf("%s: only %d examples, spec requires >=5", p.ID, len(p.Examples))
+		}
+		if len(p.NonExamples) < 5 {
+			t.Errorf("%s: only %d non-examples, spec requires >=5", p.ID, len(p.NonExamples))
+		}
+	}
+}
+
+func TestBuiltinsMatchExamples(t *testing.T) {
+	for _, p := range Builtins {
+		t.Run(p.ID, func(t *testing.T) {
+			for _, ex := range p.Examples {
+				if !p.Regex.MatchString(ex) {
+					t.Errorf("expected match on %q", ex)
+				}
+			}
+		})
+	}
+}
+
+func TestBuiltinsRejectNonExamples(t *testing.T) {
+	for _, p := range Builtins {
+		t.Run(p.ID, func(t *testing.T) {
+			for _, ne := range p.NonExamples {
+				if p.Regex.MatchString(ne) {
+					t.Errorf("unexpected match on non-example %q (false positive)", ne)
+				}
+			}
+		})
+	}
+}
+
+const realisticCorpus = `package main
+
+import "fmt"
+
+func main() {
+    // Reference: AWS IAM policies can be attached to users, groups, or roles.
+    // The AKIA prefix is reserved; STS returns temporary credentials instead.
+    fmt.Println("Hello, world!")
+}
+
+[INFO] 2026-04-17T10:32:14Z request processed in 34ms
+[WARN] 2026-04-17T10:32:15Z retry 1 of 3 for tenant AAAA-BBBB-CCCC-DDDD-EEEE
+[ERROR] 2026-04-17T10:32:16Z failed: connection refused to 10.0.0.42:5432
+[DEBUG] 2026-04-17T10:32:17Z cache hit ratio 0.98, RSS 12345678 bytes
+
+$ ls -la
+-rw-r--r--  1 user group    1234 Apr 17 10:32 README.md
+-rw-r--r--  1 user group   56789 Apr 17 10:32 go.mod
+
+commit 1a2b3c4d5e6f7890abcdef1234567890abcdef12
+Author: Alice <alice@example.com>
+Date:   Thu Apr 17 10:32:00 2026 +0000
+    docs: update README with AKIA prefix guidance
+
+PATH=/usr/local/bin:/usr/bin:/bin HOME=/home/user SHELL=/bin/bash
+AWS_REGION=us-east-1 AWS_DEFAULT_OUTPUT=json
+
+resource "aws_iam_access_key" "deploy" {
+  user = aws_iam_user.deploy.name
+}
+# Note: the AKIA prefix indicates an AWS access key ID.
+# See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
+export AWS_ACCESS_KEY_ID=   # placeholder, set by CI
+`
+
+func TestBuiltinsZeroMatchesOnCorpus(t *testing.T) {
+	for _, p := range Builtins {
+		t.Run(p.ID, func(t *testing.T) {
+			if loc := p.Regex.FindStringIndex(realisticCorpus); loc != nil {
+				matched := realisticCorpus[loc[0]:loc[1]]
+				t.Errorf("unexpected match on corpus: %q", matched)
+			}
+		})
+	}
+}
+
+func TestDefaultMask(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		showTail int
+		want     string
+	}{
+		{"standard", "AKIAIOSFODNN7EXAMPLE", 4, "AKIA************MPLE"},
+		{"full-mask", "AKIAIOSFODNN7EXAMPLE", 0, "********************"},
+		{"short-value", "AKIA", 4, "****"},
+		{"boundary", "ABCDEFGH", 4, "********"},
+		{"negative-tail", "AKIAIOSFODNN7EXAMPLE", -1, "********************"},
+		{"nine-chars", "ABCDEFGHI", 4, "ABCD*FGHI"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultMask(tt.value, tt.showTail)
+			if got != tt.want {
+				t.Errorf("DefaultMask(%q, %d) = %q, want %q", tt.value, tt.showTail, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Second of three PRs for the MVP vertical slice (#1). Adds the pattern library foundation and the first built-in pattern.

**Stacked on #10** (`feat/1-project-skeleton`). Review this diff only; merge #10 first.

## What's in

### `patterns/pattern.go`
- `Pattern` struct matching spec 002 §Pattern metadata (ID, Name, Regex, CaptureIdx, Replacement, Examples, NonExamples, Source)
- `DefaultMask(value, showTail)` — first 4 chars + stars + last N; `showTail <= 0` fully masks
- `DefaultShowTail = 4`

### `patterns/builtins.go`
- `Builtins` slice as an explicit registry (no `init()` magic)

### `patterns/aws_access_key.go`
- Regex: `AKIA[0-9A-Z]{16}`
- 5 positive examples (from AWS docs + synthetic)
- 7 negative examples: too-short, truncated, wrong-prefix, all-lowercase, partial-lowercase (`AKIAiosf…`), invalid-char, wrong-initial-char — last two added after pattern-reviewer feedback
- Source: AWS IAM reference docs

### `patterns/patterns_test.go`
- `TestBuiltinsHaveMinimumExamples` — enforces spec 002's ≥5 threshold
- `TestBuiltinsMatchExamples` / `TestBuiltinsRejectNonExamples` — validates every Example/NonExample
- `TestBuiltinsZeroMatchesOnCorpus` — 35-line realistic corpus (Go code, logs, git history, Terraform, env vars) asserting zero false positives
- `TestDefaultMask` — 6 cases including boundary, full-mask, negative-tail

## pattern-reviewer findings

The `pattern-reviewer` agent confirmed:
- **Regex is fundamentally sound.** `AKIA` + exact `{16}` bound on `[0-9A-Z]` has near-zero false-positive surface.
- **No `\b` anchor needed.** Anchoring would break detection inside JSON/YAML quoted values — desired behavior.
- **Known industry limitation:** documentation placeholder `AKIAIOSFODNN7EXAMPLE` matches structurally. This is correct for a masking tool (mask anything that looks like a secret).
- **Precision ≥99% on realistic input.** The one FP category (documentation placeholders) is accepted industry-wide.

Actionable feedback addressed in this PR:
- Added `AKIAiosfodnn7example` (partial lowercase) and `BKIAIOSFODNN7EXAMPLE` (wrong prefix, 20 chars) to NonExamples
- Expanded corpus with Terraform HCL, AKIA-mention comments, empty `AWS_ACCESS_KEY_ID=` assignment

## What's NOT in (deferred to PR#3)

- `internal/filter/` engine that applies patterns line-by-line
- CLI wiring (replacing `io.Copy` passthrough with actual masking)

## Test plan

- [ ] `go test ./patterns/... -v` — all 6 test functions pass
- [ ] `go test ./... -v` — full suite (including cmd/ tests from PR#1) passes
- [ ] `go vet ./...` clean
- [ ] Review NonExamples for completeness against realistic false-positive scenarios
- [ ] Confirm `DefaultMask("AKIAIOSFODNN7EXAMPLE", 4)` → `AKIA************MPLE`

Refs #1