### PR TITLE
feat(filter): add filter engine + wire CLI masking (PR#3 of #1)

### DIFF
--- a/cmd/mask-pipe/main.go
+++ b/cmd/mask-pipe/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/c12o-dev/mask-pipe/internal/filter"
+	"github.com/c12o-dev/mask-pipe/patterns"
 )
 
 var (
@@ -58,7 +60,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	if _, err := io.Copy(stdout, stdin); err != nil && !errors.Is(err, io.EOF) {
+	f := filter.New(patterns.Builtins, patterns.DefaultShowTail)
+	if err := f.Run(stdin, stdout); err != nil {
 		fmt.Fprintf(stderr, "mask-pipe: %v\n", err)
 		return 1
 	}

--- a/cmd/mask-pipe/main_test.go
+++ b/cmd/mask-pipe/main_test.go
@@ -50,7 +50,7 @@ func TestInvalidFlag(t *testing.T) {
 	}
 }
 
-func TestPassthrough(t *testing.T) {
+func TestCleanPassthrough(t *testing.T) {
 	input := "hello\nworld\n"
 	var stdout, stderr bytes.Buffer
 	code := run(nil, strings.NewReader(input), &stdout, &stderr)
@@ -59,5 +59,18 @@ func TestPassthrough(t *testing.T) {
 	}
 	if stdout.String() != input {
 		t.Errorf("stdout = %q, want %q", stdout.String(), input)
+	}
+}
+
+func TestMaskingEndToEnd(t *testing.T) {
+	input := "key is AKIAIOSFODNN7EXAMPLE\nno secret here\n"
+	want := "key is AKIA************MPLE\nno secret here\n"
+	var stdout, stderr bytes.Buffer
+	code := run(nil, strings.NewReader(input), &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
 	}
 }

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -1,0 +1,80 @@
+package filter
+
+import (
+	"bufio"
+	"io"
+	"strings"
+
+	"github.com/c12o-dev/mask-pipe/patterns"
+)
+
+// Filter reads lines from a reader, masks secret patterns, and writes to a writer.
+type Filter struct {
+	Patterns []*patterns.Pattern
+	ShowTail int
+}
+
+func New(pats []*patterns.Pattern, showTail int) *Filter {
+	return &Filter{Patterns: pats, ShowTail: showTail}
+}
+
+func (f *Filter) Run(in io.Reader, out io.Writer) error {
+	r := bufio.NewReaderSize(in, 1024*1024)
+	w := bufio.NewWriter(out)
+	defer w.Flush()
+	for {
+		line, err := r.ReadString('\n')
+		if len(line) > 0 {
+			hasNewline := strings.HasSuffix(line, "\n")
+			content := strings.TrimSuffix(line, "\n")
+			masked := f.MaskLine(content)
+			w.WriteString(masked)
+			if hasNewline {
+				w.WriteByte('\n')
+			}
+			w.Flush()
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (f *Filter) MaskLine(line string) string {
+	for _, p := range f.Patterns {
+		line = f.applyPattern(line, p)
+	}
+	return line
+}
+
+func (f *Filter) applyPattern(line string, p *patterns.Pattern) string {
+	indices := p.Regex.FindAllStringSubmatchIndex(line, -1)
+	if len(indices) == 0 {
+		return line
+	}
+	var b strings.Builder
+	prev := 0
+	idx := p.CaptureIdx * 2
+	for _, loc := range indices {
+		start := loc[idx]
+		end := loc[idx+1]
+		if start < 0 {
+			continue
+		}
+		b.WriteString(line[prev:start])
+		b.WriteString(f.mask(p, line[start:end]))
+		prev = end
+	}
+	b.WriteString(line[prev:])
+	return b.String()
+}
+
+func (f *Filter) mask(p *patterns.Pattern, value string) string {
+	if p.Replacement != "" {
+		return p.Replacement
+	}
+	return patterns.DefaultMask(value, f.ShowTail)
+}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -1,0 +1,106 @@
+package filter
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/c12o-dev/mask-pipe/patterns"
+)
+
+func testFilter() *Filter {
+	return New(patterns.Builtins, patterns.DefaultShowTail)
+}
+
+func TestMaskLineAWSAccessKey(t *testing.T) {
+	f := testFilter()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare key", "AKIAIOSFODNN7EXAMPLE", "AKIA************MPLE"},
+		{"key in text", "found AKIAIOSFODNN7EXAMPLE in logs", "found AKIA************MPLE in logs"},
+		{"multiple keys", "key1=AKIAIOSFODNN7EXAMPLE key2=AKIA2RAY6KGQJM7Q3EYX", "key1=AKIA************MPLE key2=AKIA************3EYX"},
+		{"no match", "no secrets here", "no secrets here"},
+		{"json context", `{"AccessKeyId":"AKIAIOSFODNN7EXAMPLE"}`, `{"AccessKeyId":"AKIA************MPLE"}`},
+		{"empty line", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := f.MaskLine(tt.input)
+			if got != tt.want {
+				t.Errorf("MaskLine(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunPreservesStreamStructure(t *testing.T) {
+	f := testFilter()
+	input := "line1 AKIAIOSFODNN7EXAMPLE\nline2 clean\nline3 AKIA2RAY6KGQJM7Q3EYX\n"
+	want := "line1 AKIA************MPLE\nline2 clean\nline3 AKIA************3EYX\n"
+	var out bytes.Buffer
+	if err := f.Run(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.String() != want {
+		t.Errorf("Run output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestRunPreservesNoTrailingNewline(t *testing.T) {
+	f := testFilter()
+	input := "AKIAIOSFODNN7EXAMPLE"
+	want := "AKIA************MPLE"
+	var out bytes.Buffer
+	if err := f.Run(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.String() != want {
+		t.Errorf("Run output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestRunEmptyInput(t *testing.T) {
+	f := testFilter()
+	var out bytes.Buffer
+	if err := f.Run(strings.NewReader(""), &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.String() != "" {
+		t.Errorf("Run output = %q, want empty", out.String())
+	}
+}
+
+func TestCaptureGroupMasking(t *testing.T) {
+	p := &patterns.Pattern{
+		ID:         "test_capture",
+		Name:       "Test Capture",
+		Regex:      regexp.MustCompile(`secret=([A-Za-z0-9]+)`),
+		CaptureIdx: 1,
+	}
+	f := New([]*patterns.Pattern{p}, 4)
+	got := f.MaskLine("config: secret=MyS3cretValue123 done")
+	want := "config: secret=MyS3********e123 done"
+	if got != want {
+		t.Errorf("MaskLine = %q, want %q", got, want)
+	}
+}
+
+func TestLiteralReplacement(t *testing.T) {
+	p := &patterns.Pattern{
+		ID:          "test_literal",
+		Name:        "Test Literal",
+		Regex:       regexp.MustCompile(`SECRET_[A-Z]+`),
+		CaptureIdx:  0,
+		Replacement: "****",
+	}
+	f := New([]*patterns.Pattern{p}, 4)
+	got := f.MaskLine("value=SECRET_TOKEN")
+	want := "value=****"
+	if got != want {
+		t.Errorf("MaskLine = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Final PR for the MVP vertical slice (#1). Adds the filter engine and wires everything together so mask-pipe actually masks secrets.

**Stacked on #11** (`feat/1-aws-access-key-pattern`) → **#10** (`feat/1-project-skeleton`). Merge order: #10 → #11 → this.

## What's in

### `internal/filter/filter.go`
- `Filter` struct holds `Patterns` + `ShowTail`
- `Run(in, out)` reads line-by-line with 1MB buffer (spec 001), applies patterns, flushes per line for streaming latency
- `MaskLine(line)` iterates patterns in priority order, replaces matches
- `applyPattern` uses `FindAllStringSubmatchIndex` to handle both whole-match (`CaptureIdx=0`) and capture-group (`CaptureIdx>0`) patterns
- `mask` chooses literal `Replacement` if set, otherwise delegates to `DefaultMask`

### `internal/filter/filter_test.go` (6 tests)
- `TestMaskLineAWSAccessKey` — bare key, key-in-text, multiple keys, no-match, JSON context, empty
- `TestRunPreservesStreamStructure` — multi-line with mixed masked/clean
- `TestRunPreservesNoTrailingNewline` — input without `\n` doesn't gain one
- `TestRunEmptyInput` — zero-length produces zero-length
- `TestCaptureGroupMasking` — verifies `CaptureIdx=1` replaces only the capture group
- `TestLiteralReplacement` — verifies `Replacement="****"` path

### `cmd/mask-pipe/main.go` changes
- Replaced `io.Copy` passthrough with `filter.New(patterns.Builtins, patterns.DefaultShowTail).Run()`
- Removed unused `errors` import

### `cmd/mask-pipe/main_test.go` additions
- Renamed `TestPassthrough` → `TestCleanPassthrough`
- Added `TestMaskingEndToEnd` — verifies AWS key gets masked through the full CLI path

## Issue #1 acceptance — all pass

```console
$ echo 'token AKIAIOSFODNN7EXAMPLE found in logs' | ./mask-pipe
token AKIA************MPLE found in logs

$ ./mask-pipe --version
mask-pipe dev (none)

$ ./mask-pipe --bogus-flag 2>/dev/null; echo $?
2

$ go test ./...
ok  github.com/c12o-dev/mask-pipe/cmd/mask-pipe
ok  github.com/c12o-dev/mask-pipe/internal/filter
ok  github.com/c12o-dev/mask-pipe/patterns
```

## Test plan

- [ ] `go test ./... -v` — all 17 tests pass
- [ ] `go vet ./...` clean
- [ ] `echo 'AKIAIOSFODNN7EXAMPLE' | ./mask-pipe` → `AKIA************MPLE`
- [ ] `echo 'no secrets' | ./mask-pipe` → `no secrets` (unchanged)
- [ ] `echo -n 'AKIAIOSFODNN7EXAMPLE' | ./mask-pipe | xxd | tail` — no trailing `\n` added
- [ ] JSON input preserves structure: `{"key":"AKIA..."}` → `{"key":"AKIA****MPLE"}`

## After merge

Once #10 → #11 → this are merged, **Issue #1 can be closed** with all acceptance criteria met.

Fixes #1