### PR TITLE
feat: add pattern library + filter engine (completes #1)

### DIFF
--- a/cmd/mask-pipe/main.go
+++ b/cmd/mask-pipe/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/c12o-dev/mask-pipe/internal/filter"
+	"github.com/c12o-dev/mask-pipe/patterns"
 )
 
 var (
@@ -58,7 +60,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	if _, err := io.Copy(stdout, stdin); err != nil && !errors.Is(err, io.EOF) {
+	f := filter.New(patterns.Builtins, patterns.DefaultShowTail)
+	if err := f.Run(stdin, stdout); err != nil {
 		fmt.Fprintf(stderr, "mask-pipe: %v\n", err)
 		return 1
 	}

--- a/cmd/mask-pipe/main_test.go
+++ b/cmd/mask-pipe/main_test.go
@@ -50,7 +50,7 @@ func TestInvalidFlag(t *testing.T) {
 	}
 }
 
-func TestPassthrough(t *testing.T) {
+func TestCleanPassthrough(t *testing.T) {
 	input := "hello\nworld\n"
 	var stdout, stderr bytes.Buffer
 	code := run(nil, strings.NewReader(input), &stdout, &stderr)
@@ -59,5 +59,18 @@ func TestPassthrough(t *testing.T) {
 	}
 	if stdout.String() != input {
 		t.Errorf("stdout = %q, want %q", stdout.String(), input)
+	}
+}
+
+func TestMaskingEndToEnd(t *testing.T) {
+	input := "key is AKIAIOSFODNN7EXAMPLE\nno secret here\n"
+	want := "key is AKIA************MPLE\nno secret here\n"
+	var stdout, stderr bytes.Buffer
+	code := run(nil, strings.NewReader(input), &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
 	}
 }

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -1,0 +1,80 @@
+package filter
+
+import (
+	"bufio"
+	"io"
+	"strings"
+
+	"github.com/c12o-dev/mask-pipe/patterns"
+)
+
+// Filter reads lines from a reader, masks secret patterns, and writes to a writer.
+type Filter struct {
+	Patterns []*patterns.Pattern
+	ShowTail int
+}
+
+func New(pats []*patterns.Pattern, showTail int) *Filter {
+	return &Filter{Patterns: pats, ShowTail: showTail}
+}
+
+func (f *Filter) Run(in io.Reader, out io.Writer) error {
+	r := bufio.NewReaderSize(in, 1024*1024)
+	w := bufio.NewWriter(out)
+	defer w.Flush()
+	for {
+		line, err := r.ReadString('\n')
+		if len(line) > 0 {
+			hasNewline := strings.HasSuffix(line, "\n")
+			content := strings.TrimSuffix(line, "\n")
+			masked := f.MaskLine(content)
+			w.WriteString(masked)
+			if hasNewline {
+				w.WriteByte('\n')
+			}
+			w.Flush()
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (f *Filter) MaskLine(line string) string {
+	for _, p := range f.Patterns {
+		line = f.applyPattern(line, p)
+	}
+	return line
+}
+
+func (f *Filter) applyPattern(line string, p *patterns.Pattern) string {
+	indices := p.Regex.FindAllStringSubmatchIndex(line, -1)
+	if len(indices) == 0 {
+		return line
+	}
+	var b strings.Builder
+	prev := 0
+	idx := p.CaptureIdx * 2
+	for _, loc := range indices {
+		start := loc[idx]
+		end := loc[idx+1]
+		if start < 0 {
+			continue
+		}
+		b.WriteString(line[prev:start])
+		b.WriteString(f.mask(p, line[start:end]))
+		prev = end
+	}
+	b.WriteString(line[prev:])
+	return b.String()
+}
+
+func (f *Filter) mask(p *patterns.Pattern, value string) string {
+	if p.Replacement != "" {
+		return p.Replacement
+	}
+	return patterns.DefaultMask(value, f.ShowTail)
+}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -1,0 +1,106 @@
+package filter
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/c12o-dev/mask-pipe/patterns"
+)
+
+func testFilter() *Filter {
+	return New(patterns.Builtins, patterns.DefaultShowTail)
+}
+
+func TestMaskLineAWSAccessKey(t *testing.T) {
+	f := testFilter()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare key", "AKIAIOSFODNN7EXAMPLE", "AKIA************MPLE"},
+		{"key in text", "found AKIAIOSFODNN7EXAMPLE in logs", "found AKIA************MPLE in logs"},
+		{"multiple keys", "key1=AKIAIOSFODNN7EXAMPLE key2=AKIA2RAY6KGQJM7Q3EYX", "key1=AKIA************MPLE key2=AKIA************3EYX"},
+		{"no match", "no secrets here", "no secrets here"},
+		{"json context", `{"AccessKeyId":"AKIAIOSFODNN7EXAMPLE"}`, `{"AccessKeyId":"AKIA************MPLE"}`},
+		{"empty line", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := f.MaskLine(tt.input)
+			if got != tt.want {
+				t.Errorf("MaskLine(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunPreservesStreamStructure(t *testing.T) {
+	f := testFilter()
+	input := "line1 AKIAIOSFODNN7EXAMPLE\nline2 clean\nline3 AKIA2RAY6KGQJM7Q3EYX\n"
+	want := "line1 AKIA************MPLE\nline2 clean\nline3 AKIA************3EYX\n"
+	var out bytes.Buffer
+	if err := f.Run(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.String() != want {
+		t.Errorf("Run output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestRunPreservesNoTrailingNewline(t *testing.T) {
+	f := testFilter()
+	input := "AKIAIOSFODNN7EXAMPLE"
+	want := "AKIA************MPLE"
+	var out bytes.Buffer
+	if err := f.Run(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.String() != want {
+		t.Errorf("Run output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestRunEmptyInput(t *testing.T) {
+	f := testFilter()
+	var out bytes.Buffer
+	if err := f.Run(strings.NewReader(""), &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.String() != "" {
+		t.Errorf("Run output = %q, want empty", out.String())
+	}
+}
+
+func TestCaptureGroupMasking(t *testing.T) {
+	p := &patterns.Pattern{
+		ID:         "test_capture",
+		Name:       "Test Capture",
+		Regex:      regexp.MustCompile(`secret=([A-Za-z0-9]+)`),
+		CaptureIdx: 1,
+	}
+	f := New([]*patterns.Pattern{p}, 4)
+	got := f.MaskLine("config: secret=MyS3cretValue123 done")
+	want := "config: secret=MyS3********e123 done"
+	if got != want {
+		t.Errorf("MaskLine = %q, want %q", got, want)
+	}
+}
+
+func TestLiteralReplacement(t *testing.T) {
+	p := &patterns.Pattern{
+		ID:          "test_literal",
+		Name:        "Test Literal",
+		Regex:       regexp.MustCompile(`SECRET_[A-Z]+`),
+		CaptureIdx:  0,
+		Replacement: "****",
+	}
+	f := New([]*patterns.Pattern{p}, 4)
+	got := f.MaskLine("value=SECRET_TOKEN")
+	want := "value=****"
+	if got != want {
+		t.Errorf("MaskLine = %q, want %q", got, want)
+	}
+}

--- a/patterns/aws_access_key.go
+++ b/patterns/aws_access_key.go
@@ -1,0 +1,27 @@
+package patterns
+
+import "regexp"
+
+var awsAccessKey = &Pattern{
+	ID:         "aws_access_key",
+	Name:       "AWS Access Key ID",
+	Regex:      regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+	CaptureIdx: 0,
+	Examples: []string{
+		"AKIAIOSFODNN7EXAMPLE",
+		"AKIAI44QH8DHBEXAMPLE",
+		"AKIAJQABCDEFGHIJKLMN",
+		"AKIAZZZZ9999AAAABBBB",
+		"AKIA2RAY6KGQJM7Q3EYX",
+	},
+	NonExamples: []string{
+		"AKIA",
+		"AKIAIOSFODNN7EXAM",
+		"XKIAIOSFODNN7EXAMPLE",
+		"akiaiosfodnn7example",
+		"AKIAIOSFODNN!EXAMPLE",
+		"AKIAiosfodnn7example",
+		"BKIAIOSFODNN7EXAMPLE",
+	},
+	Source: "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html",
+}

--- a/patterns/builtins.go
+++ b/patterns/builtins.go
@@ -1,0 +1,6 @@
+package patterns
+
+// Builtins is the default set of built-in patterns, in match-priority order.
+var Builtins = []*Pattern{
+	awsAccessKey,
+}

--- a/patterns/doc.go
+++ b/patterns/doc.go
@@ -1,0 +1,5 @@
+// Package patterns defines the built-in secret detection patterns shipped with mask-pipe.
+//
+// This package is top-level (per ADR 0003) for findability. It is NOT a stable
+// external API in v1; importers outside this module get no semver guarantees.
+package patterns

--- a/patterns/pattern.go
+++ b/patterns/pattern.go
@@ -1,0 +1,36 @@
+package patterns
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Pattern describes a single secret-detection rule.
+//
+// Replacement: empty string applies DefaultMask (show head + stars + tail);
+// non-empty string is used as a literal replacement (e.g. "****").
+type Pattern struct {
+	ID          string
+	Name        string
+	Regex       *regexp.Regexp
+	CaptureIdx  int
+	Replacement string
+	Examples    []string
+	NonExamples []string
+	Source      string
+}
+
+const DefaultShowTail = 4
+
+// DefaultMask keeps the first 4 and last showTail characters visible.
+// showTail <= 0 fully masks the value.
+func DefaultMask(value string, showTail int) string {
+	if showTail <= 0 {
+		return strings.Repeat("*", len(value))
+	}
+	const head = 4
+	if len(value) <= head+showTail {
+		return strings.Repeat("*", len(value))
+	}
+	return value[:head] + strings.Repeat("*", len(value)-head-showTail) + value[len(value)-showTail:]
+}

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1,0 +1,110 @@
+package patterns
+
+import (
+	"testing"
+)
+
+func TestBuiltinsHaveMinimumExamples(t *testing.T) {
+	for _, p := range Builtins {
+		if len(p.Examples) < 5 {
+			t.Errorf("%s: only %d examples, spec requires >=5", p.ID, len(p.Examples))
+		}
+		if len(p.NonExamples) < 5 {
+			t.Errorf("%s: only %d non-examples, spec requires >=5", p.ID, len(p.NonExamples))
+		}
+	}
+}
+
+func TestBuiltinsMatchExamples(t *testing.T) {
+	for _, p := range Builtins {
+		t.Run(p.ID, func(t *testing.T) {
+			for _, ex := range p.Examples {
+				if !p.Regex.MatchString(ex) {
+					t.Errorf("expected match on %q", ex)
+				}
+			}
+		})
+	}
+}
+
+func TestBuiltinsRejectNonExamples(t *testing.T) {
+	for _, p := range Builtins {
+		t.Run(p.ID, func(t *testing.T) {
+			for _, ne := range p.NonExamples {
+				if p.Regex.MatchString(ne) {
+					t.Errorf("unexpected match on non-example %q (false positive)", ne)
+				}
+			}
+		})
+	}
+}
+
+const realisticCorpus = `package main
+
+import "fmt"
+
+func main() {
+    // Reference: AWS IAM policies can be attached to users, groups, or roles.
+    // The AKIA prefix is reserved; STS returns temporary credentials instead.
+    fmt.Println("Hello, world!")
+}
+
+[INFO] 2026-04-17T10:32:14Z request processed in 34ms
+[WARN] 2026-04-17T10:32:15Z retry 1 of 3 for tenant AAAA-BBBB-CCCC-DDDD-EEEE
+[ERROR] 2026-04-17T10:32:16Z failed: connection refused to 10.0.0.42:5432
+[DEBUG] 2026-04-17T10:32:17Z cache hit ratio 0.98, RSS 12345678 bytes
+
+$ ls -la
+-rw-r--r--  1 user group    1234 Apr 17 10:32 README.md
+-rw-r--r--  1 user group   56789 Apr 17 10:32 go.mod
+
+commit 1a2b3c4d5e6f7890abcdef1234567890abcdef12
+Author: Alice <alice@example.com>
+Date:   Thu Apr 17 10:32:00 2026 +0000
+    docs: update README with AKIA prefix guidance
+
+PATH=/usr/local/bin:/usr/bin:/bin HOME=/home/user SHELL=/bin/bash
+AWS_REGION=us-east-1 AWS_DEFAULT_OUTPUT=json
+
+resource "aws_iam_access_key" "deploy" {
+  user = aws_iam_user.deploy.name
+}
+# Note: the AKIA prefix indicates an AWS access key ID.
+# See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
+export AWS_ACCESS_KEY_ID=   # placeholder, set by CI
+`
+
+func TestBuiltinsZeroMatchesOnCorpus(t *testing.T) {
+	for _, p := range Builtins {
+		t.Run(p.ID, func(t *testing.T) {
+			if loc := p.Regex.FindStringIndex(realisticCorpus); loc != nil {
+				matched := realisticCorpus[loc[0]:loc[1]]
+				t.Errorf("unexpected match on corpus: %q", matched)
+			}
+		})
+	}
+}
+
+func TestDefaultMask(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		showTail int
+		want     string
+	}{
+		{"standard", "AKIAIOSFODNN7EXAMPLE", 4, "AKIA************MPLE"},
+		{"full-mask", "AKIAIOSFODNN7EXAMPLE", 0, "********************"},
+		{"short-value", "AKIA", 4, "****"},
+		{"boundary", "ABCDEFGH", 4, "********"},
+		{"negative-tail", "AKIAIOSFODNN7EXAMPLE", -1, "********************"},
+		{"nine-chars", "ABCDEFGHI", 4, "ABCD*FGHI"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultMask(tt.value, tt.showTail)
+			if got != tt.want {
+				t.Errorf("DefaultMask(%q, %d) = %q, want %q", tt.value, tt.showTail, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Combines the work from closed PRs #11 and #12 into a single PR targeting main. Skeleton (#10) and ADR (#9) are already merged.

## What's in

### Pattern library (`patterns/`)
- `Pattern` struct per spec 002 (ID, Name, Regex, CaptureIdx, Replacement, Examples, NonExamples, Source)
- `DefaultMask(value, showTail)` — first 4 + stars + last N; `showTail <= 0` fully masks
- `Builtins` registry (explicit, no `init()` magic)
- `aws_access_key` pattern: `AKIA[0-9A-Z]{16}`, 5 examples, 7 non-examples
- Reviewed by `pattern-reviewer` agent: precision ≥99% confirmed

### Filter engine (`internal/filter/`)
- Line-by-line `Run(in, out)` with 1MB buffer, per-line flush for streaming latency
- `FindAllStringSubmatchIndex` handles both whole-match and capture-group patterns
- Literal `Replacement` support for full-mask patterns (e.g. DB passwords)
- Preserves trailing-newline fidelity

### CLI wire-up (`cmd/mask-pipe/main.go`)
- Replaced `io.Copy` passthrough with `filter.New(patterns.Builtins, …).Run()`

## Tests (17 total, all passing)

| Package | Tests |
|---|---|
| `cmd/mask-pipe` | flags, clean passthrough, E2E masking |
| `patterns` | example/non-example validation, corpus zero-match, DefaultMask |
| `internal/filter` | mask-line variants, stream structure, capture groups, literal replacement, empty input |

## Issue #1 acceptance — verified

```console
$ echo 'token AKIAIOSFODNN7EXAMPLE found' | ./mask-pipe
token AKIA************MPLE found

$ ./mask-pipe --version
mask-pipe dev (none)

$ ./mask-pipe --bogus 2>/dev/null; echo $?
2

$ go test ./...
ok  (all 17 tests pass)
```

Fixes #1