### PR TITLE
ci: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.23']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Build
+        run: go build ./cmd/mask-pipe
+
+      - name: Test
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Format check
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "Files not formatted:"
+            gofmt -l .
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a minimal CI workflow that protects main and PRs with automated checks.

## Jobs

| Step | Command | Purpose |
|---|---|---|
| Build | `go build ./cmd/mask-pipe` | Compile check |
| Test | `go test -race -coverprofile=coverage.out ./...` | Unit tests + race detector |
| Vet | `go vet ./...` | Static analysis |
| Format | `gofmt -l .` | Formatting enforcement |

Go 1.23 on ubuntu-latest. Matrix ready for future Go version additions.

## Test plan

- [ ] CI runs on this PR itself and all steps pass
- [ ] Future PRs get status checks