### PR TITLE
feat: add multi-line buffering + pem_private_key (completes all 8 patterns)

### DIFF
--- a/docs/adr/0004-multiline-buffering.md
+++ b/docs/adr/0004-multiline-buffering.md
@@ -1,0 +1,51 @@
+# 0004 — Multi-line pattern matching via begin/end marker buffering
+
+- **Status:** accepted
+- **Date:** 2026-04-17
+
+## Context
+
+The filter engine processes stdin line-by-line for streaming latency (spec 001: "Output MUST be flushed after each input line"). PEM private key blocks span 20–50 lines. Matching them requires seeing the entire block before deciding whether to mask.
+
+Three approaches were considered (see Alternatives). The key constraint is preserving streaming latency for the 99%+ of lines that don't contain multi-line secrets.
+
+## Decision
+
+Add optional **begin/end marker buffering** to the filter engine:
+
+1. The `Pattern` struct gains three optional fields: `Multiline bool`, `BeginMarker *regexp.Regexp`, `EndMarker *regexp.Regexp`.
+2. When the engine encounters a line matching a multiline pattern's `BeginMarker`, it enters **buffering mode**: lines are accumulated instead of flushed.
+3. Buffering continues until `EndMarker` is matched or a safety limit (100 lines or 64KB, whichever comes first) is exceeded.
+4. On `EndMarker`: the buffered block is joined and the full `Regex` is applied. If matched, the block is replaced with `Replacement` (e.g. `[REDACTED PRIVATE KEY]`).
+5. On safety limit exceeded: the buffered lines are flushed **unmodified** (fail-open). A warning is written to stderr.
+6. Single-line patterns (the default) are unaffected — `Multiline` defaults to `false`.
+
+## Consequences
+
+**Positive:**
+
+- Streaming latency is preserved for all single-line patterns (no buffering overhead)
+- PEM private keys are fully masked with zero false positives (explicit markers)
+- Fail-open on safety limit means malformed input never causes data loss
+- The same mechanism can later support YAML secret blocks or multi-line JSON if needed
+
+**Negative / trade-offs:**
+
+- Lines inside a PEM block experience latency equal to the block's total read time (typically <10ms for a 2KB key, acceptable)
+- If a `BEGIN` marker appears without a matching `END`, up to 100 lines are buffered before flushing — a brief delay for malformed input
+- The Pattern struct gains 3 fields that are nil/false for most patterns — minor ergonomic cost
+
+## Alternatives considered
+
+- **Full-input accumulation.** Read all of stdin into memory, then match multi-line patterns. Rejected: breaks streaming guarantee (spec 001). A `tail -f | mask-pipe` pipeline would hang until EOF.
+
+- **Sliding window.** Keep a rolling buffer of N lines, apply multi-line regex over the window. Rejected: PEM blocks vary widely in size (RSA-2048 = ~27 lines, RSA-4096 = ~52 lines). A fixed window either misses large keys or wastes memory on every line.
+
+- **Defer to v2.** Skip `pem_private_key` entirely. Rejected: PEM keys have zero false positives (explicit markers) and are one of the most commonly leaked secret types. Omitting them weakens mask-pipe's value proposition.
+
+## References
+
+- [Issue #16](https://github.com/c12o-dev/mask-pipe/issues/16) — spec_change issue
+- [Issue #8](https://github.com/c12o-dev/mask-pipe/issues/8) — pem_private_key pattern
+- [docs/specs/001-cli-interface.md](../specs/001-cli-interface.md) — streaming latency requirement
+- [docs/specs/002-pattern-library.md](../specs/002-pattern-library.md) — PEM pattern definition

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,7 @@ ADRs are append-only. Don't edit accepted ADRs; if a decision changes, write a n
 | [0001](0001-language-go.md) | Implementation language: Go | accepted |
 | [0002](0002-explicit-pipe-default.md) | Explicit pipe as default integration pattern | accepted |
 | [0003](0003-project-layout.md) | Project layout: `cmd/` + top-level `patterns/` + `internal/` | accepted |
+| [0004](0004-multiline-buffering.md) | Multi-line pattern matching via begin/end marker buffering | accepted |
 
 ## When to write an ADR
 

--- a/docs/specs/001-cli-interface.md
+++ b/docs/specs/001-cli-interface.md
@@ -26,6 +26,7 @@ $ <some-command> | mask-pipe [flags]
 **Input:**
 - `stdin` — the raw byte stream to filter
 - mask-pipe MUST operate line-by-line to preserve streaming behavior (e.g., `tail -f`)
+- **Exception:** multi-line patterns (e.g., PEM private keys) use begin/end marker buffering. Lines between a begin marker and its corresponding end marker are accumulated before matching. A safety limit (100 lines or 64KB) prevents unbounded buffering; if exceeded, buffered lines are flushed unmodified and a warning is written to stderr. See [ADR 0004](../adr/0004-multiline-buffering.md).
 - Lines MAY exceed the default `bufio.MaxScanTokenSize` (64KB); mask-pipe MUST handle lines up to at least 1MB without crashing
 
 **Output:**

--- a/docs/specs/002-pattern-library.md
+++ b/docs/specs/002-pattern-library.md
@@ -34,14 +34,17 @@ Each pattern in the codebase MUST declare:
 
 ```go
 type Pattern struct {
-    ID          string   // Stable identifier (e.g., "aws_access_key")
-    Name        string   // Human-readable name
+    ID          string         // Stable identifier (e.g., "aws_access_key")
+    Name        string         // Human-readable name
     Regex       *regexp.Regexp
-    CaptureIdx  int      // Which capture group holds the value to mask (0 = entire match)
-    Replacement string   // "****" or custom per-pattern
-    Examples    []string // At least 5 strings that SHOULD match
-    NonExamples []string // At least 5 strings that SHOULD NOT match
-    Source      string   // URL to vendor doc or spec justifying the format
+    CaptureIdx  int            // Which capture group holds the value to mask (0 = entire match)
+    Replacement string         // "****" or custom per-pattern
+    Examples    []string       // At least 5 strings that SHOULD match
+    NonExamples []string       // At least 5 strings that SHOULD NOT match
+    Source      string         // URL to vendor doc or spec justifying the format
+    Multiline   bool           // If true, engine uses begin/end marker buffering (ADR 0004)
+    BeginMarker *regexp.Regexp // Line that starts a multi-line block (required if Multiline)
+    EndMarker   *regexp.Regexp // Line that ends a multi-line block (required if Multiline)
 }
 ```
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -2,16 +2,23 @@ package filter
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/c12o-dev/mask-pipe/patterns"
 )
 
+const (
+	maxBufLines = 100
+	maxBufBytes = 64 * 1024
+)
+
 // Filter reads lines from a reader, masks secret patterns, and writes to a writer.
 type Filter struct {
 	Patterns []*patterns.Pattern
 	ShowTail int
+	Stderr   io.Writer // optional; multi-line safety-limit warnings go here
 }
 
 func New(pats []*patterns.Pattern, showTail int) *Filter {
@@ -22,19 +29,74 @@ func (f *Filter) Run(in io.Reader, out io.Writer) error {
 	r := bufio.NewReaderSize(in, 1024*1024)
 	w := bufio.NewWriter(out)
 	defer w.Flush()
+
+	var mlRaw []string // multi-line buffer (raw lines with \n preserved)
+	var mlPat *patterns.Pattern
+	var mlBytes int
+
 	for {
 		line, err := r.ReadString('\n')
 		if len(line) > 0 {
 			hasNewline := strings.HasSuffix(line, "\n")
 			content := strings.TrimSuffix(line, "\n")
-			masked := f.MaskLine(content)
-			w.WriteString(masked)
-			if hasNewline {
-				w.WriteByte('\n')
+
+			if mlPat != nil {
+				// In buffering mode — store raw line
+				mlRaw = append(mlRaw, line)
+				mlBytes += len(line)
+
+				if mlPat.EndMarker.MatchString(content) {
+					// End marker found — join contents, apply regex
+					contents := make([]string, len(mlRaw))
+					for i, l := range mlRaw {
+						contents[i] = strings.TrimSuffix(l, "\n")
+					}
+					block := strings.Join(contents, "\n")
+					masked := f.applyPattern(block, mlPat)
+					w.WriteString(masked)
+					if hasNewline {
+						w.WriteByte('\n')
+					}
+					w.Flush()
+					mlRaw = nil
+					mlPat = nil
+					mlBytes = 0
+				} else if len(mlRaw) >= maxBufLines || mlBytes >= maxBufBytes {
+					// Safety limit — flush unmodified
+					if f.Stderr != nil {
+						fmt.Fprintf(f.Stderr, "mask-pipe: multi-line buffer limit exceeded, flushing %d lines unmasked\n", len(mlRaw))
+					}
+					for _, rawLine := range mlRaw {
+						w.WriteString(rawLine)
+					}
+					w.Flush()
+					mlRaw = nil
+					mlPat = nil
+					mlBytes = 0
+				}
+				// Otherwise keep buffering
+			} else if p := f.matchBeginMarker(content); p != nil {
+				// Start buffering for a multi-line pattern
+				mlRaw = []string{line}
+				mlPat = p
+				mlBytes = len(line)
+			} else {
+				// Normal single-line processing
+				masked := f.MaskLine(content)
+				w.WriteString(masked)
+				if hasNewline {
+					w.WriteByte('\n')
+				}
+				w.Flush()
 			}
-			w.Flush()
 		}
 		if err == io.EOF {
+			// Flush any remaining multi-line buffer unmodified
+			if mlPat != nil {
+				for _, rawLine := range mlRaw {
+					w.WriteString(rawLine)
+				}
+			}
 			return nil
 		}
 		if err != nil {
@@ -43,8 +105,20 @@ func (f *Filter) Run(in io.Reader, out io.Writer) error {
 	}
 }
 
+func (f *Filter) matchBeginMarker(line string) *patterns.Pattern {
+	for _, p := range f.Patterns {
+		if p.Multiline && p.BeginMarker != nil && p.BeginMarker.MatchString(line) {
+			return p
+		}
+	}
+	return nil
+}
+
 func (f *Filter) MaskLine(line string) string {
 	for _, p := range f.Patterns {
+		if p.Multiline {
+			continue
+		}
 		line = f.applyPattern(line, p)
 	}
 	return line

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"bytes"
+	"io"
 	"regexp"
 	"strings"
 	"testing"
@@ -102,5 +103,45 @@ func TestLiteralReplacement(t *testing.T) {
 	want := "value=****"
 	if got != want {
 		t.Errorf("MaskLine = %q, want %q", got, want)
+	}
+}
+
+func TestMultilinePEMBlock(t *testing.T) {
+	f := testFilter()
+	input := "before\n-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRi\nbase64data==\n-----END RSA PRIVATE KEY-----\nafter\n"
+	want := "before\n[REDACTED PRIVATE KEY]\nafter\n"
+	var out bytes.Buffer
+	if err := f.Run(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.String() != want {
+		t.Errorf("Run output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestMultilinePEMWithSurroundingSecrets(t *testing.T) {
+	f := testFilter()
+	input := "key=AKIAIOSFODNN7EXAMPLE\n-----BEGIN PRIVATE KEY-----\ndata\n-----END PRIVATE KEY-----\nclean\n"
+	want := "key=AKIA************MPLE\n[REDACTED PRIVATE KEY]\nclean\n"
+	var out bytes.Buffer
+	if err := f.Run(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.String() != want {
+		t.Errorf("Run output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestMultilineBeginWithoutEnd(t *testing.T) {
+	f := testFilter()
+	f.Stderr = io.Discard
+	// Begin marker without end — should flush unmodified at EOF
+	input := "-----BEGIN RSA PRIVATE KEY-----\norphaned data\n"
+	var out bytes.Buffer
+	if err := f.Run(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.String() != input {
+		t.Errorf("Run output = %q, want %q (unmodified)", out.String(), input)
 	}
 }

--- a/patterns/builtins.go
+++ b/patterns/builtins.go
@@ -9,4 +9,5 @@ var Builtins = []*Pattern{
 	stripeKey,
 	jwt,
 	dbURLPassword,
+	pemPrivateKey,
 }

--- a/patterns/pattern.go
+++ b/patterns/pattern.go
@@ -9,6 +9,10 @@ import (
 //
 // Replacement: empty string applies DefaultMask (show head + stars + tail);
 // non-empty string is used as a literal replacement (e.g. "****").
+//
+// Multiline patterns use begin/end marker buffering (ADR 0004). The filter
+// engine accumulates lines between BeginMarker and EndMarker, then applies
+// Regex to the joined block.
 type Pattern struct {
 	ID          string
 	Name        string
@@ -18,6 +22,9 @@ type Pattern struct {
 	Examples    []string
 	NonExamples []string
 	Source      string
+	Multiline   bool
+	BeginMarker *regexp.Regexp
+	EndMarker   *regexp.Regexp
 }
 
 const DefaultShowTail = 4

--- a/patterns/pem_private_key.go
+++ b/patterns/pem_private_key.go
@@ -1,0 +1,29 @@
+package patterns
+
+import "regexp"
+
+var pemPrivateKey = &Pattern{
+	ID:          "pem_private_key",
+	Name:        "PEM private key block",
+	Regex:       regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`),
+	CaptureIdx:  0,
+	Replacement: "[REDACTED PRIVATE KEY]",
+	Examples: []string{
+		"-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAH\n-----END RSA PRIVATE KEY-----",
+		"-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIBkg\n-----END EC PRIVATE KEY-----",
+		"-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIA\n-----END PRIVATE KEY-----",
+		"-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjE\n-----END OPENSSH PRIVATE KEY-----",
+		"-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIFDjBABgkqhkiG9w0B\n-----END ENCRYPTED PRIVATE KEY-----",
+	},
+	NonExamples: []string{
+		"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0B\n-----END PUBLIC KEY-----",
+		"-----BEGIN CERTIFICATE-----\nMIICpDCCAYwCCQC7RXjA\n-----END CERTIFICATE-----",
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"-----END RSA PRIVATE KEY-----",
+		"The key format uses -----BEGIN PRIVATE KEY----- markers.",
+	},
+	Source:      "https://datatracker.ietf.org/doc/html/rfc7468",
+	Multiline:   true,
+	BeginMarker: regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`),
+	EndMarker:   regexp.MustCompile(`-----END [A-Z ]*PRIVATE KEY-----`),
+}


### PR DESCRIPTION
## Summary

Implements the last built-in pattern from spec 002 (\`pem_private_key\`) by adding multi-line buffering support to the filter engine. All 8 spec'd patterns are now complete.

## Multi-line buffering (ADR 0004)

The \`Pattern\` struct gains three optional fields:
- \`Multiline bool\`
- \`BeginMarker *regexp.Regexp\`
- \`EndMarker *regexp.Regexp\`

When the engine encounters a line matching \`BeginMarker\`:
1. Switches to buffering mode — lines are accumulated, not flushed
2. On \`EndMarker\`: joins buffer, applies full regex, replaces if matched
3. Safety limit (100 lines / 64KB): flushes unmodified + stderr warning (fail-open)
4. On EOF without EndMarker: flushes unmodified

Single-line patterns are completely unaffected.

## pem_private_key pattern

- Regex: \`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----\`
- Replacement: \`[REDACTED PRIVATE KEY]\`
- 5 Examples: RSA, EC, OPENSSH, ENCRYPTED, generic
- 5 NonExamples: public key, certificate, lone begin/end markers, prose mention

## Spec changes

- **001**: Added multi-line buffering exception to the "line-by-line" streaming rule
- **002**: Added \`Multiline\`, \`BeginMarker\`, \`EndMarker\` to Pattern struct definition

## Test plan

- [x] \`go test ./... -v\` — all tests pass (including 3 new multi-line tests)
- [x] \`go vet ./...\` clean
- [x] E2E: PEM block in stdin → \`[REDACTED PRIVATE KEY]\` on stdout
- [x] E2E: PEM block surrounded by other secrets → both masked correctly
- [x] E2E: Orphaned BEGIN without END → flushed unmodified at EOF
- [ ] CI: GitHub Actions should run on this PR

Fixes #8, Fixes #16