### PR TITLE
feat(config): TOML config file support (spec 003)

### DIFF
--- a/cmd/mask-pipe/main.go
+++ b/cmd/mask-pipe/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/c12o-dev/mask-pipe/internal/config"
 	"github.com/c12o-dev/mask-pipe/internal/filter"
 	"github.com/c12o-dev/mask-pipe/patterns"
 )
@@ -21,8 +22,11 @@ Usage:
   <command> | mask-pipe [flags]
 
 Flags:
-  -h, --help      show this help and exit
-  -V, --version   show version and exit
+  -h, --help            show this help and exit
+  -V, --version         show version and exit
+      --config <path>   path to config file (default: auto-detect)
+      --mask-char <c>   override masking character
+      --show-tail <N>   show last N chars of masked values (0 = full mask)
 
 Example:
   aws sts get-caller-identity 2>&1 | mask-pipe
@@ -39,11 +43,17 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	var (
 		showHelp    bool
 		showVersion bool
+		configPath  string
+		maskChar    string
+		showTail    int
 	)
 	fs.BoolVar(&showHelp, "help", false, "")
 	fs.BoolVar(&showHelp, "h", false, "")
 	fs.BoolVar(&showVersion, "version", false, "")
 	fs.BoolVar(&showVersion, "V", false, "")
+	fs.StringVar(&configPath, "config", "", "")
+	fs.StringVar(&maskChar, "mask-char", "", "")
+	fs.IntVar(&showTail, "show-tail", -1, "")
 
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintf(stderr, "mask-pipe: %v\n", err)
@@ -60,10 +70,58 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	f := filter.New(patterns.Builtins, patterns.DefaultShowTail)
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "mask-pipe: %v\n", err)
+		return 1
+	}
+
+	// CLI flags override config
+	if maskChar != "" {
+		cfg.Display.MaskChar = maskChar
+	}
+	if showTail >= 0 {
+		cfg.Display.ShowTail = showTail
+	}
+
+	pats := buildPatterns(cfg)
+
+	f := &filter.Filter{
+		Patterns:  pats,
+		ShowTail:  cfg.Display.ShowTail,
+		MaskChar:  cfg.MaskCharStr(),
+		Allowlist: cfg.AllowlistRegexps(),
+		Stderr:    stderr,
+	}
+
 	if err := f.Run(stdin, stdout); err != nil {
 		fmt.Fprintf(stderr, "mask-pipe: %v\n", err)
 		return 1
 	}
 	return 0
+}
+
+func buildPatterns(cfg *config.Config) []*patterns.Pattern {
+	var pats []*patterns.Pattern
+
+	// Built-in patterns (filtered by config)
+	for _, p := range patterns.Builtins {
+		if cfg.IsBuiltinEnabled(p.ID) {
+			pats = append(pats, p)
+		}
+	}
+
+	// Custom patterns from config
+	for _, cp := range cfg.CustomPatterns() {
+		p := &patterns.Pattern{
+			ID:          "custom:" + cp.Name,
+			Name:        cp.Name,
+			Regex:       cp.Regex,
+			CaptureIdx:  0,
+			Replacement: cp.Replacement,
+		}
+		pats = append(pats, p)
+	}
+
+	return pats
 }

--- a/docs/adr/0005-toml-parser.md
+++ b/docs/adr/0005-toml-parser.md
@@ -1,0 +1,37 @@
+# 0005 — TOML parser: BurntSushi/toml
+
+- **Status:** accepted
+- **Date:** 2026-04-17
+
+## Context
+
+Spec 003 mandates TOML as the config format. Go's standard library does not include a TOML parser. We need an external dependency — the first one added to this project.
+
+## Decision
+
+Use `github.com/BurntSushi/toml` (v1.x).
+
+## Consequences
+
+**Positive:**
+
+- De facto standard Go TOML parser — written by the TOML spec co-author
+- Minimal API (`toml.DecodeFile` is all we need), no transitive dependencies
+- Full TOML v1.0 spec compliance
+- Active maintenance with a stable v1 API
+
+**Negative / trade-offs:**
+
+- First external dependency — binary size increases ~200KB
+- Must track upstream for security fixes (low risk; the library is pure Go with no syscalls)
+
+## Alternatives considered
+
+- **pelletier/go-toml v2** — Good performance but larger API surface and more transitive dependencies. No clear advantage for our simple config.
+- **Hand-rolled parser** — TOML v1.0 is deceptively complex (datetime types, inline tables, dotted keys). Not worth the effort or the bugs.
+- **Switch to JSON/YAML** — Rejected by spec 003. TOML is the better fit for user-edited config files (comments, readable syntax).
+
+## References
+
+- [docs/specs/003-config-format.md](../specs/003-config-format.md)
+- [Issue #18](https://github.com/c12o-dev/mask-pipe/issues/18)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@ ADRs are append-only. Don't edit accepted ADRs; if a decision changes, write a n
 | [0002](0002-explicit-pipe-default.md) | Explicit pipe as default integration pattern | accepted |
 | [0003](0003-project-layout.md) | Project layout: `cmd/` + top-level `patterns/` + `internal/` | accepted |
 | [0004](0004-multiline-buffering.md) | Multi-line pattern matching via begin/end marker buffering | accepted |
+| [0005](0005-toml-parser.md) | TOML parser: BurntSushi/toml | accepted |
 
 ## When to write an ADR
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/c12o-dev/mask-pipe
 
 go 1.23
+
+require github.com/BurntSushi/toml v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"fmt"
+	"github.com/BurntSushi/toml"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+type Config struct {
+	Builtin   map[string]bool  `toml:"builtin"`
+	Custom    []CustomPattern  `toml:"custom"`
+	Display   DisplayConfig    `toml:"display"`
+	Allowlist []AllowlistEntry `toml:"allowlist"`
+}
+
+type CustomPattern struct {
+	Name        string `toml:"name"`
+	Pattern     string `toml:"pattern"`
+	ShowTail    *int   `toml:"show_tail"`
+	Replacement string `toml:"replacement"`
+}
+
+type DisplayConfig struct {
+	MaskChar string `toml:"mask_char"`
+	ShowTail int    `toml:"show_tail"`
+	Color    bool   `toml:"color"`
+}
+
+type AllowlistEntry struct {
+	Name    string `toml:"name"`
+	Pattern string `toml:"pattern"`
+}
+
+func Default() *Config {
+	return &Config{
+		Builtin: nil,
+		Display: DisplayConfig{
+			MaskChar: "*",
+			ShowTail: 4,
+			Color:    true,
+		},
+	}
+}
+
+// Load finds and parses the config file. Returns Default() if no file found.
+func Load(explicitPath string) (*Config, error) {
+	path := findConfigFile(explicitPath)
+	if path == "" {
+		return Default(), nil
+	}
+	return loadFile(path)
+}
+
+func findConfigFile(explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if env := os.Getenv("MASK_PIPE_CONFIG"); env != "" {
+		return env
+	}
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		p := filepath.Join(xdg, "mask-pipe", "config.toml")
+		if fileExists(p) {
+			return p
+		}
+	} else if home, err := os.UserHomeDir(); err == nil {
+		p := filepath.Join(home, ".config", "mask-pipe", "config.toml")
+		if fileExists(p) {
+			return p
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		p := filepath.Join(home, ".mask-pipe.toml")
+		if fileExists(p) {
+			return p
+		}
+	}
+	return ""
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func loadFile(path string) (*Config, error) {
+	cfg := Default()
+	if _, err := toml.DecodeFile(path, cfg); err != nil {
+		return nil, fmt.Errorf("config %s: %w", path, err)
+	}
+	if err := validate(cfg); err != nil {
+		return nil, fmt.Errorf("config %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+func validate(cfg *Config) error {
+	if cfg.Display.MaskChar != "" {
+		runes := []rune(cfg.Display.MaskChar)
+		if len(runes) != 1 {
+			return fmt.Errorf("[display].mask_char must be a single character, got %q", cfg.Display.MaskChar)
+		}
+	}
+
+	names := make(map[string]bool)
+	for i, c := range cfg.Custom {
+		if c.Name == "" {
+			return fmt.Errorf("[[custom]][%d]: name is required", i)
+		}
+		if c.Pattern == "" {
+			return fmt.Errorf("[[custom]] %q: pattern is required", c.Name)
+		}
+		if _, err := regexp.Compile(c.Pattern); err != nil {
+			return fmt.Errorf("[[custom]] %q: invalid regex: %w", c.Name, err)
+		}
+		if names[c.Name] {
+			return fmt.Errorf("[[custom]] %q: duplicate name", c.Name)
+		}
+		names[c.Name] = true
+	}
+
+	for i, a := range cfg.Allowlist {
+		if a.Name == "" {
+			return fmt.Errorf("[[allowlist]][%d]: name is required", i)
+		}
+		if a.Pattern == "" {
+			return fmt.Errorf("[[allowlist]] %q: pattern is required", a.Name)
+		}
+		if _, err := regexp.Compile(a.Pattern); err != nil {
+			return fmt.Errorf("[[allowlist]] %q: invalid regex: %w", a.Name, err)
+		}
+	}
+	return nil
+}
+
+// IsBuiltinEnabled checks if a built-in pattern is enabled. Default: true.
+func (c *Config) IsBuiltinEnabled(id string) bool {
+	if c.Builtin == nil {
+		return true
+	}
+	enabled, exists := c.Builtin[id]
+	if !exists {
+		return true
+	}
+	return enabled
+}
+
+// MaskCharRune returns the mask character as a rune. Defaults to '*'.
+func (c *Config) MaskCharRune() rune {
+	if c.Display.MaskChar == "" {
+		return '*'
+	}
+	return []rune(c.Display.MaskChar)[0]
+}
+
+// AllowlistRegexps compiles and returns allowlist patterns.
+func (c *Config) AllowlistRegexps() []*regexp.Regexp {
+	var res []*regexp.Regexp
+	for _, a := range c.Allowlist {
+		re, _ := regexp.Compile(a.Pattern) // already validated
+		res = append(res, re)
+	}
+	return res
+}
+
+// CustomPatternRegexps returns compiled custom patterns ready for use.
+func (c *Config) CustomPatterns() []CompiledCustom {
+	var res []CompiledCustom
+	for _, cp := range c.Custom {
+		re, _ := regexp.Compile(cp.Pattern) // already validated
+		cc := CompiledCustom{
+			Name:        cp.Name,
+			Regex:       re,
+			Replacement: cp.Replacement,
+			ShowTail:    c.Display.ShowTail,
+		}
+		if cp.ShowTail != nil {
+			cc.ShowTail = *cp.ShowTail
+		}
+		res = append(res, cc)
+	}
+	return res
+}
+
+type CompiledCustom struct {
+	Name        string
+	Regex       *regexp.Regexp
+	Replacement string
+	ShowTail    int
+}
+
+// MaskChar returns the mask character string (for use with strings.Repeat).
+func (c *Config) MaskCharStr() string {
+	if c.Display.MaskChar == "" {
+		return "*"
+	}
+	return string([]rune(c.Display.MaskChar)[:1])
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadDefault(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Display.ShowTail != 4 {
+		t.Errorf("ShowTail = %d, want 4", cfg.Display.ShowTail)
+	}
+	if cfg.Display.MaskChar != "*" {
+		t.Errorf("MaskChar = %q, want *", cfg.Display.MaskChar)
+	}
+}
+
+func TestLoadBuiltinToggle(t *testing.T) {
+	path := writeTempConfig(t, `
+[builtin]
+jwt = false
+aws_access_key = true
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.IsBuiltinEnabled("jwt") {
+		t.Error("jwt should be disabled")
+	}
+	if !cfg.IsBuiltinEnabled("aws_access_key") {
+		t.Error("aws_access_key should be enabled")
+	}
+	if !cfg.IsBuiltinEnabled("stripe_key") {
+		t.Error("stripe_key should default to enabled")
+	}
+}
+
+func TestLoadDisplayOverrides(t *testing.T) {
+	path := writeTempConfig(t, `
+[display]
+mask_char = "#"
+show_tail = 2
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Display.MaskChar != "#" {
+		t.Errorf("MaskChar = %q, want #", cfg.Display.MaskChar)
+	}
+	if cfg.Display.ShowTail != 2 {
+		t.Errorf("ShowTail = %d, want 2", cfg.Display.ShowTail)
+	}
+}
+
+func TestLoadCustomPatterns(t *testing.T) {
+	path := writeTempConfig(t, `
+[[custom]]
+name = "my-key"
+pattern = 'myco-[a-z]{32}'
+show_tail = 0
+
+[[custom]]
+name = "webhook"
+pattern = 'https://hooks\.example\.com/[a-z]+'
+replacement = "[REDACTED URL]"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Custom) != 2 {
+		t.Fatalf("Custom count = %d, want 2", len(cfg.Custom))
+	}
+	compiled := cfg.CustomPatterns()
+	if len(compiled) != 2 {
+		t.Fatalf("Compiled count = %d, want 2", len(compiled))
+	}
+	if compiled[0].ShowTail != 0 {
+		t.Errorf("first custom ShowTail = %d, want 0", compiled[0].ShowTail)
+	}
+	if compiled[1].Replacement != "[REDACTED URL]" {
+		t.Errorf("second custom Replacement = %q", compiled[1].Replacement)
+	}
+}
+
+func TestLoadAllowlist(t *testing.T) {
+	path := writeTempConfig(t, `
+[[allowlist]]
+name = "test-key"
+pattern = 'AKIAIOSFODNN7EXAMPLE'
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	regexps := cfg.AllowlistRegexps()
+	if len(regexps) != 1 {
+		t.Fatalf("Allowlist count = %d, want 1", len(regexps))
+	}
+	if !regexps[0].MatchString("AKIAIOSFODNN7EXAMPLE") {
+		t.Error("allowlist should match the example key")
+	}
+}
+
+func TestInvalidRegexFails(t *testing.T) {
+	path := writeTempConfig(t, `
+[[custom]]
+name = "bad"
+pattern = '[invalid'
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid regex")
+	}
+}
+
+func TestDuplicateNameFails(t *testing.T) {
+	path := writeTempConfig(t, `
+[[custom]]
+name = "dup"
+pattern = 'a'
+
+[[custom]]
+name = "dup"
+pattern = 'b'
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for duplicate name")
+	}
+}
+
+func TestInvalidMaskCharFails(t *testing.T) {
+	path := writeTempConfig(t, `
+[display]
+mask_char = "**"
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for multi-char mask_char")
+	}
+}
+
+func TestExplicitConfigNotFound(t *testing.T) {
+	_, err := Load("/nonexistent/path/config.toml")
+	if err == nil {
+		t.Fatal("expected error for nonexistent explicit config")
+	}
+}

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/c12o-dev/mask-pipe/patterns"
@@ -16,9 +17,11 @@ const (
 
 // Filter reads lines from a reader, masks secret patterns, and writes to a writer.
 type Filter struct {
-	Patterns []*patterns.Pattern
-	ShowTail int
-	Stderr   io.Writer // optional; multi-line safety-limit warnings go here
+	Patterns  []*patterns.Pattern
+	ShowTail  int
+	MaskChar  string
+	Allowlist []*regexp.Regexp
+	Stderr    io.Writer // optional; multi-line safety-limit warnings go here
 }
 
 func New(pats []*patterns.Pattern, showTail int) *Filter {
@@ -138,17 +141,30 @@ func (f *Filter) applyPattern(line string, p *patterns.Pattern) string {
 		if start < 0 {
 			continue
 		}
+		matched := line[start:end]
+		if f.isAllowlisted(matched) {
+			continue
+		}
 		b.WriteString(line[prev:start])
-		b.WriteString(f.mask(p, line[start:end]))
+		b.WriteString(f.mask(p, matched))
 		prev = end
 	}
 	b.WriteString(line[prev:])
 	return b.String()
 }
 
+func (f *Filter) isAllowlisted(value string) bool {
+	for _, re := range f.Allowlist {
+		if re.MatchString(value) {
+			return true
+		}
+	}
+	return false
+}
+
 func (f *Filter) mask(p *patterns.Pattern, value string) string {
 	if p.Replacement != "" {
 		return p.Replacement
 	}
-	return patterns.DefaultMask(value, f.ShowTail)
+	return patterns.DefaultMask(value, f.ShowTail, f.MaskChar)
 }

--- a/patterns/pattern.go
+++ b/patterns/pattern.go
@@ -29,15 +29,18 @@ type Pattern struct {
 
 const DefaultShowTail = 4
 
-// DefaultMask keeps the first 4 and last showTail characters visible.
-// showTail <= 0 fully masks the value.
-func DefaultMask(value string, showTail int) string {
+// DefaultMask keeps the first 4 and last showTail characters visible,
+// replacing the middle with maskChar. showTail <= 0 fully masks.
+func DefaultMask(value string, showTail int, maskChar string) string {
+	if maskChar == "" {
+		maskChar = "*"
+	}
 	if showTail <= 0 {
-		return strings.Repeat("*", len(value))
+		return strings.Repeat(maskChar, len(value))
 	}
 	const head = 4
 	if len(value) <= head+showTail {
-		return strings.Repeat("*", len(value))
+		return strings.Repeat(maskChar, len(value))
 	}
-	return value[:head] + strings.Repeat("*", len(value)-head-showTail) + value[len(value)-showTail:]
+	return value[:head] + strings.Repeat(maskChar, len(value)-head-showTail) + value[len(value)-showTail:]
 }

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -133,7 +133,7 @@ func TestDefaultMask(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := DefaultMask(tt.value, tt.showTail)
+			got := DefaultMask(tt.value, tt.showTail, "*")
 			if got != tt.want {
 				t.Errorf("DefaultMask(%q, %d) = %q, want %q", tt.value, tt.showTail, got, tt.want)
 			}


### PR DESCRIPTION
## Summary

Implements config file support per spec 003. This is the extensibility foundation — users can now toggle built-in patterns, add custom patterns, configure masking style, and allowlist known-safe values.

## Features

| Feature | Example |
|---|---|
| Builtin toggle | \`[builtin]\njwt = false\` → JWT passes through |
| Custom pattern | \`[[custom]]\nname = "my-key"\npattern = 'myco-[a-z]{32}'\` |
| Display config | \`[display]\nmask_char = "#"\nshow_tail = 2\` |
| Allowlist | \`[[allowlist]]\nname = "aws-doc"\npattern = 'AKIAIOSFODNN7EXAMPLE'\` |
| CLI override | \`--mask-char X --show-tail 0\` overrides config |
| File discovery | \`--config\` > \`\$MASK_PIPE_CONFIG\` > XDG > \`~/.mask-pipe.toml\` |

## New files

- \`internal/config/config.go\` — Config struct, Load(), validate, file discovery
- \`internal/config/config_test.go\` — 9 tests covering all features + error cases
- \`docs/adr/0005-toml-parser.md\` — justifies BurntSushi/toml as first external dep

## Changes to existing code

- \`patterns/pattern.go\`: \`DefaultMask\` gains \`maskChar\` parameter
- \`internal/filter/filter.go\`: Filter gains \`MaskChar\`, \`Allowlist\` fields
- \`cmd/mask-pipe/main.go\`: config loading, \`--config\`/\`--mask-char\`/\`--show-tail\` flags, pattern assembly from config

## E2E verification

\`\`\`console
$ echo '[builtin]\njwt = false' > /tmp/cfg.toml
$ echo 'eyJ...JWT... AKIAIOSFODNN7EXAMPLE' | ./mask-pipe --config /tmp/cfg.toml
eyJ...JWT... AKIA************MPLE     # JWT disabled, AWS masked

$ echo 'AKIAIOSFODNN7EXAMPLE' | ./mask-pipe --mask-char '#' --show-tail 2
AKIA################LE

$ echo '[[allowlist]]\nname="x"\npattern="AKIAIOSFODNN7EXAMPLE"' > /tmp/al.toml
$ echo 'AKIAIOSFODNN7EXAMPLE' | ./mask-pipe --config /tmp/al.toml
AKIAIOSFODNN7EXAMPLE   # allowlisted, passes through
\`\`\`

## Test plan

- [x] \`go test ./...\` — all tests pass (config: 9, filter: 9, patterns: 6, cmd: 5)
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] E2E: builtin toggle, mask char, show tail, allowlist, CLI overrides
- [ ] CI: verify on GitHub Actions

Fixes #18