### PR TITLE
feat(cli): add --dry-run and --no-color flags

### DIFF
--- a/cmd/mask-pipe/main.go
+++ b/cmd/mask-pipe/main.go
@@ -29,6 +29,8 @@ Flags:
       --config <path>   path to config file (default: auto-detect)
       --mask-char <c>   override masking character
       --show-tail <N>   show last N chars of masked values (0 = full mask)
+      --dry-run         highlight matches without masking
+      --no-color        disable ANSI color (also: NO_COLOR env var)
 
 Subcommands:
   list-patterns   print all active built-in and custom patterns
@@ -53,6 +55,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		configPath  string
 		maskChar    string
 		showTail    int
+		dryRun      bool
+		noColor     bool
 	)
 	fs.BoolVar(&showHelp, "help", false, "")
 	fs.BoolVar(&showHelp, "h", false, "")
@@ -61,6 +65,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	fs.StringVar(&configPath, "config", "", "")
 	fs.StringVar(&maskChar, "mask-char", "", "")
 	fs.IntVar(&showTail, "show-tail", -1, "")
+	fs.BoolVar(&dryRun, "dry-run", false, "")
+	fs.BoolVar(&noColor, "no-color", false, "")
 
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintf(stderr, "mask-pipe: %v\n", err)
@@ -107,6 +113,11 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		cfg.Display.ShowTail = showTail
 	}
 
+	// NO_COLOR env var overrides color setting
+	if os.Getenv("NO_COLOR") != "" {
+		noColor = true
+	}
+
 	pats := buildPatterns(cfg)
 
 	f := &filter.Filter{
@@ -114,6 +125,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		ShowTail:  cfg.Display.ShowTail,
 		MaskChar:  cfg.MaskCharStr(),
 		Allowlist: cfg.AllowlistRegexps(),
+		DryRun:   dryRun,
+		Color:    !noColor && cfg.Display.Color,
 		Stderr:    stderr,
 	}
 

--- a/cmd/mask-pipe/main_test.go
+++ b/cmd/mask-pipe/main_test.go
@@ -115,3 +115,35 @@ func TestUnknownSubcommand(t *testing.T) {
 		t.Errorf("exit code = %d, want 2", code)
 	}
 }
+
+func TestDryRunNoColor(t *testing.T) {
+	input := "key AKIAIOSFODNN7EXAMPLE here\n"
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--dry-run", "--no-color"}, strings.NewReader(input), &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "[MATCH:aws_access_key]") {
+		t.Errorf("dry-run output missing MATCH tag: %q", out)
+	}
+	if !strings.Contains(out, "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("dry-run should preserve original value: %q", out)
+	}
+}
+
+func TestDryRunWithColor(t *testing.T) {
+	input := "AKIAIOSFODNN7EXAMPLE\n"
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--dry-run"}, strings.NewReader(input), &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "\033[31m") {
+		t.Errorf("dry-run with color should contain ANSI red: %q", out)
+	}
+	if !strings.Contains(out, "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("dry-run should preserve original value: %q", out)
+	}
+}

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -21,7 +21,9 @@ type Filter struct {
 	ShowTail  int
 	MaskChar  string
 	Allowlist []*regexp.Regexp
-	Stderr    io.Writer // optional; multi-line safety-limit warnings go here
+	DryRun   bool
+	Color    bool   // emit ANSI color in dry-run mode
+	Stderr    io.Writer
 }
 
 func New(pats []*patterns.Pattern, showTail int) *Filter {
@@ -163,8 +165,23 @@ func (f *Filter) isAllowlisted(value string) bool {
 }
 
 func (f *Filter) mask(p *patterns.Pattern, value string) string {
+	if f.DryRun {
+		return f.dryRunHighlight(p, value)
+	}
 	if p.Replacement != "" {
 		return p.Replacement
 	}
 	return patterns.DefaultMask(value, f.ShowTail, f.MaskChar)
+}
+
+const (
+	ansiRed   = "\033[31m"
+	ansiReset = "\033[0m"
+)
+
+func (f *Filter) dryRunHighlight(p *patterns.Pattern, value string) string {
+	if f.Color {
+		return ansiRed + value + ansiReset
+	}
+	return "[MATCH:" + p.ID + "]" + value + "[/MATCH]"
 }


### PR DESCRIPTION
## Summary

Implements the last two display flags from spec 001.

### \`--dry-run\`
Highlights matches without replacing them:
- With color (default): ANSI red (\`\033[31m\`) around matched text
- Without color: \`[MATCH:pattern_id]value[/MATCH]\` tags for machine parsing

### \`--no-color\`
Disables ANSI colors. Also auto-enabled by \`NO_COLOR\` environment variable (standard).

## E2E

\`\`\`console
$ echo 'AKIAIOSFODNN7EXAMPLE' | mask-pipe --dry-run --no-color
[MATCH:aws_access_key]AKIAIOSFODNN7EXAMPLE[/MATCH]

$ echo 'postgres://user:secret@host/db' | mask-pipe --dry-run --no-color
postgres://user:[MATCH:db_url_password]secret[/MATCH]@host/db
\`\`\`

## Test plan

- [x] \`go test ./...\` — all tests pass (2 new dry-run tests)
- [x] E2E: --dry-run --no-color shows MATCH tags
- [x] E2E: --dry-run without --no-color shows ANSI codes

Fixes #22