### PR TITLE
ci: add goreleaser config and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,51 @@
+version: 2
+
+project_name: mask-pipe
+
+before:
+  hooks:
+    - go test ./...
+
+builds:
+  - main: ./cmd/mask-pipe
+    binary: mask-pipe
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^ci:"
+      - "^test:"
+
+brews:
+  - repository:
+      owner: c12o-dev
+      name: homebrew-tap
+    homepage: https://github.com/c12o-dev/mask-pipe
+    description: Filter secrets from terminal output
+    license: MIT
+    skip_upload: auto


### PR DESCRIPTION
## Summary

Adds automated cross-platform release pipeline via goreleaser.

## What's in

### \`.goreleaser.yml\`
- Cross-compile: linux/darwin/windows × amd64/arm64
- \`-ldflags\` injects \`main.version\` and \`main.commit\`
- Archives: tar.gz (zip on Windows) + checksums
- Homebrew formula generation (skip_upload until tap repo exists)
- Pre-hook: \`go test ./...\` as release gate

### \`.github/workflows/release.yml\`
- Triggers on \`v*\` tags
- Uses goreleaser-action v6 with goreleaser v2

## Usage

\`\`\`bash
git tag v0.1.0
git push --tags
\`\`\`

## Test plan

- [ ] Tag a pre-release (\`v0.1.0-rc.1\`) and verify the workflow runs
- [ ] Verify 6 binaries appear in the GitHub release
- [ ] \`./mask-pipe --version\` prints the tagged version