### PR TITLE
style: fix gofmt alignment

### DIFF
--- a/cmd/mask-pipe/main.go
+++ b/cmd/mask-pipe/main.go
@@ -125,8 +125,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		ShowTail:  cfg.Display.ShowTail,
 		MaskChar:  cfg.MaskCharStr(),
 		Allowlist: cfg.AllowlistRegexps(),
-		DryRun:   dryRun,
-		Color:    !noColor && cfg.Display.Color,
+		DryRun:    dryRun,
+		Color:     !noColor && cfg.Display.Color,
 		Stderr:    stderr,
 	}
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -21,8 +21,8 @@ type Filter struct {
 	ShowTail  int
 	MaskChar  string
 	Allowlist []*regexp.Regexp
-	DryRun   bool
-	Color    bool   // emit ANSI color in dry-run mode
+	DryRun    bool
+	Color     bool // emit ANSI color in dry-run mode
 	Stderr    io.Writer
 }
 


### PR DESCRIPTION
Fix tab alignment in Filter struct and main.go that caused CI gofmt check to fail.