### PR TITLE
fix(ci): skip Homebrew upload until tap repo exists

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,4 +48,4 @@ brews:
     homepage: https://github.com/c12o-dev/mask-pipe
     description: Filter secrets from terminal output
     license: MIT
-    skip_upload: auto
+    skip_upload: true  # change to 'auto' after creating c12o-dev/homebrew-tap


### PR DESCRIPTION
Sets `skip_upload: true` in goreleaser Homebrew config. v0.1.0 release published successfully (7 assets) but the workflow failed because `c12o-dev/homebrew-tap` doesn't exist yet. Change to `auto` when the tap repo is created.