### PR TITLE
ci: enable Homebrew formula upload

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,4 +48,4 @@ brews:
     homepage: https://github.com/c12o-dev/mask-pipe
     description: Filter secrets from terminal output
     license: MIT
-    skip_upload: true  # change to 'auto' after creating c12o-dev/homebrew-tap
+    skip_upload: auto


### PR DESCRIPTION
Switches `skip_upload` from `true` to `auto` now that `c12o-dev/homebrew-tap` exists. Next release will auto-push the formula.