### PR TITLE
docs: add brew install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ TruffleHog guards your code. secretlint guards your commits. **mask-pipe guards 
 ## Install
 
 ```bash
+# Homebrew (macOS / Linux)
+brew install c12o-dev/tap/mask-pipe
+
 # Go
 go install github.com/c12o-dev/mask-pipe/cmd/mask-pipe@latest
 


### PR DESCRIPTION
Adds `brew install c12o-dev/tap/mask-pipe` as the first install option. Formula is live at https://github.com/c12o-dev/homebrew-tap.